### PR TITLE
Fix about link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,10 +13,6 @@ images = "img/me.JPG"
 
 [menu]
 [[menu.main]]
-    name = "About"
-    url = "/about/"
-    weight = 1
-[[menu.main]]
     name = "curriculum"
     url = "/curriculum/"
     weight = 3

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -1,6 +1,6 @@
 ---
 title:
-linkTitle:
+linkTitle: About
 weight: 1
 menu:
   main: {}


### PR DESCRIPTION
This fixes the error with the about page by removing the reference link from the `config.toml` and adding a `linkTitle` to the about page